### PR TITLE
⚡ Optimize plugin directory loading to use async I/O

### DIFF
--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -110,8 +110,8 @@ impl PluginRuntime {
             return Ok(loaded);
         }
 
-        let entries = std::fs::read_dir(&self.plugin_dir)?;
-        for entry in entries.filter_map(|e| e.ok()) {
+        let mut entries = tokio::fs::read_dir(&self.plugin_dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
             if path.is_dir() {
                 // Look for plugin.toml


### PR DESCRIPTION
💡 **What:** Replaced the blocking synchronous `std::fs::read_dir` inside the async `load_all_plugins` context with the non-blocking asynchronous `tokio::fs::read_dir`.

🎯 **Why:** `std::fs::read_dir` blocks the thread running the tokio runtime while waiting for I/O completion. Using `tokio::fs::read_dir` ensures that async threads are not blocked, significantly improving the scalability and responsiveness of the application, particularly when scanning large directories of plugins.

📊 **Measured Improvement:** We were unable to provide an exact benchmark because testing and profiling suites failed due to extensive pre-existing compiler errors in other areas of the application. However, moving from blocking I/O to async I/O within a Tokio worker context is a well-known optimization that prevents starvation of background tasks and directly addresses the reported synchronous directory read issue.

---
*PR created automatically by Jules for task [4698403089604262865](https://jules.google.com/task/4698403089604262865) started by @Rcidshacker*