### PR TITLE
🧹 Remove unimplemented audio seeking and fix track restart

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -310,7 +310,7 @@ impl App {
 
         // If more than 3 seconds into track, restart current track
         if self.playback_state.position > 3.0 {
-            self.seek_to(0.0);
+            self.play_track_at_index(self.library.queue_index);
             return;
         }
 
@@ -429,11 +429,6 @@ impl App {
                 self.library.queue_index = 0;
             }
         }
-    }
-
-    /// Seek to position
-    fn seek_to(&mut self, _position: f64) {
-        // TODO: Implement seeking in audio engine
     }
 
     /// Navigate up in the library list


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was an unimplemented `seek_to` method in `src/app.rs`.
💡 **Why:** It removes dead code that had a TODO attached. By using `play_track_at_index`, track restarting now works properly in `previous_track()`.
✅ **Verification:** Verified with `cargo check` and `cargo test` to ensure no related compilation errors were introduced. Checked git diff and code review was approved.
✨ **Result:** The code correctly handles restarting a track within `previous_track` instead of no-op, without needing complex implementations in the audio engine layer.

---
*PR created automatically by Jules for task [11613146188158085715](https://jules.google.com/task/11613146188158085715) started by @Rcidshacker*