### PR TITLE
🔒 Fix missing permission checks when creating plugin directories

### DIFF
--- a/src/plugins/registry.rs
+++ b/src/plugins/registry.rs
@@ -186,7 +186,14 @@ impl PluginRegistry {
 
         // Ensure directory exists
         if !self.plugin_dir.exists() {
-            std::fs::create_dir_all(&self.plugin_dir)?;
+            let mut builder = std::fs::DirBuilder::new();
+            builder.recursive(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::DirBuilderExt;
+                builder.mode(0o700);
+            }
+            builder.create(&self.plugin_dir)?;
             return Ok(());
         }
 
@@ -302,7 +309,14 @@ impl PluginRegistry {
 
         // Create plugin directory
         let plugin_dir = self.plugin_dir.join(id);
-        std::fs::create_dir_all(&plugin_dir)?;
+        let mut builder = std::fs::DirBuilder::new();
+        builder.recursive(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        builder.create(&plugin_dir)?;
 
         // Create manifest
         let manifest = PluginManifest {

--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -74,7 +74,14 @@ impl PluginRuntime {
     pub fn new(plugin_dir: PathBuf) -> Result<Self, PluginError> {
         // Ensure plugin directory exists
         if !plugin_dir.exists() {
-            std::fs::create_dir_all(&plugin_dir)?;
+            let mut builder = std::fs::DirBuilder::new();
+            builder.recursive(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::DirBuilderExt;
+                builder.mode(0o700);
+            }
+            builder.create(&plugin_dir)?;
         }
 
         Ok(Self {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Plugin directories were being created using default permissions via `std::fs::create_dir_all`. They have now been updated to use `std::fs::DirBuilder` to apply restrictive `0o700` permissions upon creation.

⚠️ **Risk:** The potential impact if left unfixed
In shared environments or if Symphony is run as a privileged user, other users might have write access to the plugin directory and could inject malicious plugins. 

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced `std::fs::create_dir_all(&plugin_dir)?` with a custom `DirBuilder` setup that applies `mode(0o700)` atomically under Unix systems, eliminating the potential for a Time-Of-Check to Time-Of-Use vulnerability. The fix applies to three locations across `src/plugins/registry.rs` and `src/plugins/runtime.rs`.

---
*PR created automatically by Jules for task [2220120955274083355](https://jules.google.com/task/2220120955274083355) started by @Rcidshacker*