### PR TITLE
🧪 test: add coverage for polybar_format in statusline

### DIFF
--- a/src/integrations/statusline.rs
+++ b/src/integrations/statusline.rs
@@ -141,7 +141,7 @@ impl StatusLine {
         if let Some((title, artist, duration, position)) = track {
             let icon = if is_playing { "%{F#00ff00}▶%{F-}" } else { "⏸" };
             format!(
-                "{} {} - {} %{F#888}{}%{F-}/%{F#888}{}%{F-}",
+                "{} {} - {} %{{F#888}}{}%{{F-}}/%{{F#888}}{}%{{F-}}",
                 icon,
                 truncate(title, 25),
                 truncate(artist, 15),
@@ -272,5 +272,33 @@ mod tests {
         assert_eq!(format_duration(60), "1:00");
         assert_eq!(format_duration(125), "2:05");
         assert_eq!(format_duration(3661), "61:01");
+    }
+
+    #[test]
+    fn test_polybar_format() {
+        let status = StatusLine::polybar_format(
+            Some(("Test Song", "Test Artist", 180, 90)),
+            true,
+        );
+        assert!(status.contains("Test Song"));
+        assert!(status.contains("Test Artist"));
+        assert!(status.contains("%{F#00ff00}▶%{F-}"));
+        assert!(status.contains("%{F#888}1:30%{F-}"));
+        assert!(status.contains("%{F#888}3:00%{F-}"));
+    }
+
+    #[test]
+    fn test_polybar_format_paused() {
+        let status = StatusLine::polybar_format(
+            Some(("Test Song", "Test Artist", 180, 90)),
+            false,
+        );
+        assert!(status.contains("⏸"));
+    }
+
+    #[test]
+    fn test_polybar_format_empty() {
+        let status = StatusLine::polybar_format(None, false);
+        assert_eq!(status, "");
     }
 }


### PR DESCRIPTION
🎯 **What:** Added tests for the `polybar_format` function to address missing unit test coverage. Additionally fixed a bug where unescaped braces would cause a compile-time error.
📊 **Coverage:** The test suite now fully covers the `polybar_format` function in three specific scenarios:
1. `test_polybar_format`: Verify output values and symbols for a playing track.
2. `test_polybar_format_paused`: Verify symbols (⏸) for a paused track.
3. `test_polybar_format_empty`: Verify that it correctly returns an empty string when `None` track is provided.
✨ **Result:** Test coverage improved for the `statusline` integration formatting logic, preventing potential regressions.

---
*PR created automatically by Jules for task [1730384417954751676](https://jules.google.com/task/1730384417954751676) started by @Rcidshacker*