### PR TITLE
⚡ Replace Synchronous I/O with Asynchronous in Plugin Runtime

### DIFF
--- a/src/plugins/runtime.rs
+++ b/src/plugins/runtime.rs
@@ -106,19 +106,19 @@ impl PluginRuntime {
     pub async fn load_all_plugins(&mut self) -> Result<Vec<String>, PluginError> {
         let mut loaded = Vec::new();
 
-        if !self.plugin_dir.exists() {
+        if !tokio::fs::try_exists(&self.plugin_dir).await.unwrap_or(false) {
             return Ok(loaded);
         }
 
-        let entries = std::fs::read_dir(&self.plugin_dir)?;
-        for entry in entries.filter_map(|e| e.ok()) {
+        let mut entries = tokio::fs::read_dir(&self.plugin_dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
             let path = entry.path();
-            if path.is_dir() {
+            if entry.file_type().await?.is_dir() {
                 // Look for plugin.toml
                 let manifest_path = path.join("plugin.toml");
                 let wasm_path = path.join("plugin.wasm");
 
-                if manifest_path.exists() {
+                if tokio::fs::try_exists(&manifest_path).await.unwrap_or(false) {
                     match self.load_plugin(&manifest_path, &wasm_path).await {
                         Ok(name) => {
                             loaded.push(name);
@@ -142,7 +142,7 @@ impl PluginRuntime {
         wasm_path: &Path,
     ) -> Result<String, PluginError> {
         // Read and parse manifest
-        let manifest_content = std::fs::read_to_string(manifest_path)?;
+        let manifest_content = tokio::fs::read_to_string(manifest_path).await?;
         let manifest: PluginManifest = toml::from_str(&manifest_content)
             .map_err(|e| PluginError::InvalidManifest(e.to_string()))?;
 
@@ -159,7 +159,7 @@ impl PluginRuntime {
         info!("Loading plugin: {} v{}", name, manifest.version);
 
         // Verify WASM file exists
-        if !wasm_path.exists() {
+        if !tokio::fs::try_exists(wasm_path).await.unwrap_or(false) {
             // Create placeholder for built-in plugins that don't have WASM yet
             let plugin = LoadedPlugin {
                 manifest,


### PR DESCRIPTION
💡 **What:** The optimization implemented
- Replaced synchronous `std::fs` calls with asynchronous `tokio::fs` equivalents in `src/plugins/runtime.rs`.
- Updated `load_all_plugins` and `load_plugin` to use non-blocking I/O.
- Specifically replaced `std::fs::read_to_string`, `std::fs::read_dir`, and synchronous file/directory existence/type checks.

🎯 **Why:** The performance problem it solves
- Synchronous I/O in an `async` function blocks the Tokio executor thread.
- In a music player that handles concurrent tasks (audio processing, UI updates, streaming, and plugin execution), blocking the executor can lead to UI stutters or audio dropouts during plugin loading.
- By using `tokio::fs`, the executor can yield and handle other tasks while waiting for the disk I/O to complete, improving responsiveness.

📊 **Measured Improvement:**
- While I was unable to run a meaningful benchmark due to environment-specific dependency issues (missing crates in offline mode), the rationale for this change is a well-established best practice in asynchronous Rust programming. Replacing blocking I/O with async I/O is a direct and guaranteed way to prevent thread starvation in the Tokio runtime, leading to better concurrency and overall system throughput.


---
*PR created automatically by Jules for task [18194305584256339386](https://jules.google.com/task/18194305584256339386) started by @Rcidshacker*